### PR TITLE
{BLOCKED}(maint) Update vscode-textmate module to 4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-editor-syntax",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "balanced-match": {
@@ -25,7 +25,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -71,12 +71,12 @@
       "integrity": "sha512-hh97pBcNEc24OQn+CBYu1pp9kcEqp3dE0oO52QIoQkDREnZYHUD1YcKcGvHU+k9lgCmIXHslJfGTie58zjhLnA==",
       "dev": true,
       "requires": {
-        "coffee-script": "1.12.7",
-        "cson-parser": "1.3.5",
-        "editions": "1.3.4",
-        "extract-opts": "3.3.1",
-        "requirefresh": "2.1.0",
-        "safefs": "4.1.0"
+        "coffee-script": "^1.12.7",
+        "cson-parser": "^1.3.4",
+        "editions": "^1.3.3",
+        "extract-opts": "^3.3.1",
+        "requirefresh": "^2.1.0",
+        "safefs": "^4.1.0"
       }
     },
     "cson-parser": {
@@ -85,7 +85,7 @@
       "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.12.7"
+        "coffee-script": "^1.10.0"
       }
     },
     "debug": {
@@ -109,8 +109,8 @@
       "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
       "dev": true,
       "requires": {
-        "editions": "1.3.4",
-        "typechecker": "4.5.0"
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
       }
     },
     "editions": {
@@ -143,16 +143,10 @@
       "integrity": "sha1-WrvtyYwNUgLjJ4cn+Rktfghsa+E=",
       "dev": true,
       "requires": {
-        "eachr": "3.2.0",
-        "editions": "1.3.4",
-        "typechecker": "4.5.0"
+        "eachr": "^3.2.0",
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
       }
-    },
-    "fast-plist": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/fast-plist/-/fast-plist-0.1.2.tgz",
-      "integrity": "sha1-pFr/NFGWAG1AbKbNzQX2kFHvNbg=",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -166,12 +160,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -204,8 +198,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -226,8 +220,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "md5": {
@@ -236,9 +230,9 @@
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "dev": true,
       "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "1.1.6"
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
       }
     },
     "minimatch": {
@@ -247,7 +241,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -290,9 +284,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true
     },
     "once": {
@@ -301,16 +295,16 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "oniguruma": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-6.2.1.tgz",
-      "integrity": "sha1-pQ7mlkKEStHSUmhaqxhxcbBuzgQ=",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/oniguruma/-/oniguruma-7.0.2.tgz",
+      "integrity": "sha512-zCsdNxTrrB4yVPMxhcIODGv1p4NVBu9WvsWnIGhMpu5djO4MQWXrC7YKjtza+OyoRqqgy27CqYWa1h5e2DDbig==",
       "dev": true,
       "requires": {
-        "nan": "2.8.0"
+        "nan": "^2.10.0"
       }
     },
     "path-is-absolute": {
@@ -325,7 +319,7 @@
       "integrity": "sha1-dC3Mwg86lpGNZsbxWX3I/+vE9vU=",
       "dev": true,
       "requires": {
-        "editions": "1.3.4"
+        "editions": "^1.1.1"
       }
     },
     "safefs": {
@@ -334,8 +328,8 @@
       "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
       "dev": true,
       "requires": {
-        "editions": "1.3.4",
-        "graceful-fs": "4.1.11"
+        "editions": "^1.1.1",
+        "graceful-fs": "^4.1.4"
       }
     },
     "sprintf-js": {
@@ -350,7 +344,7 @@
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "dev": true,
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "typechecker": {
@@ -359,17 +353,16 @@
       "integrity": "sha512-bqPE/ck3bVIaXP7gMKTKSHrypT32lpYTpiqzPYeYzdSQnmaGvaGhy7TnN/M/+5R+2rs/kKcp9ZLPRp/Q9Yj+4w==",
       "dev": true,
       "requires": {
-        "editions": "1.3.4"
+        "editions": "^1.3.4"
       }
     },
     "vscode-textmate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-3.2.0.tgz",
-      "integrity": "sha1-h+WrHtMEYykac/4os3pYWQp3d9w=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-4.1.0.tgz",
+      "integrity": "sha512-gaN87CCT7J8tZ3yHYpEEI6maaKag3gGgVyDDvtkI7oHxbp39b8g7wzziZd5x8SiIddKbctyYiAI52sd8wPGYOg==",
       "dev": true,
       "requires": {
-        "fast-plist": "0.1.2",
-        "oniguruma": "6.2.1"
+        "oniguruma": "^7.0.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "expect.js": "^0.3.1",
     "mocha": "^5.0.1",
-    "vscode-textmate": "^3.2.0",
+    "vscode-textmate": "^4.0.0",
     "js-yaml": "^3.10.0",
     "md5": "^2.2.1",
     "cson": "^5.1.0"

--- a/scripts/inspect.js
+++ b/scripts/inspect.js
@@ -1,5 +1,4 @@
 // Adapted from https://github.com/Microsoft/vscode-textmate/blob/master/scripts/inspect.js
-
 if (process.argv.length < 4) {
   console.log('usage: node index.js <mainGrammarPath> [<additionalGrammarPath1> ...] <filePath>');
   process.exit(0);
@@ -10,57 +9,61 @@ var FILE_PATH = process.argv[process.argv.length - 1];
 
 process.env['VSCODE_TEXTMATE_DEBUG'] = true;
 
-var Registry = require('vscode-textmate').Registry;
+var fs = require('fs');
+var main = require('vscode-textmate'); // The original inspect.js uses '../out/main' but we use the module
+
+var Registry = main.Registry;
 var registry = new Registry();
-
-console.log('LOADING GRAMMAR: ' + GRAMMAR_PATHS[0]);
-var grammar = registry.loadGrammarFromPathSync(GRAMMAR_PATHS[0]);
-for (var i = 1; i < GRAMMAR_PATHS.length; i++) {
-  console.log('LOADING GRAMMAR: ' + GRAMMAR_PATHS[i]);
-  registry.loadGrammarFromPathSync(GRAMMAR_PATHS[i]);
+var grammarPromise = null;
+for (let path of GRAMMAR_PATHS) {
+  console.log('LOADING GRAMMAR: ' + path);
+  var content = fs.readFileSync(path).toString();
+  var rawGrammar = main.parseRawGrammar(content, path);
+  var g = registry.addGrammar(rawGrammar);
+  grammarPromise = grammarPromise || g;
 }
+grammarPromise.then(grammar => {
+  var fileContents = fs.readFileSync(FILE_PATH).toString();
+  var lines = fileContents.split(/\r\n|\r|\n/);
+  var ruleStack = null;
+  var lastElementId = 0;
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i];
 
-var fileContents = require('fs').readFileSync(FILE_PATH).toString();
-lines = fileContents.split(/\r\n|\r|\n/);
+    console.log('');
+    console.log('');
+    console.log('===========================================');
+    console.log('TOKENIZING LINE ' + (i + 1) + ': |' + line + '|');
 
-var ruleStack = null;
-var lastElementId = 0;
-for (var i = 0; i < lines.length; i++) {
-  var line = lines[i];
+    var r = grammar.tokenizeLine(line, ruleStack);
 
-  console.log('');
-  console.log('');
-  console.log('===========================================');
-  console.log('TOKENIZING LINE ' + (i + 1) + ': |' + line + '|');
+    console.log('');
 
-  var r = grammar.tokenizeLine(line, ruleStack);
-
-  console.log('');
-
-  var stackElement = r.ruleStack;
-  var cnt = 0;
-  while (stackElement) {
-    cnt++;
-    stackElement = stackElement._parent;
-  }
-
-  console.log('@@LINE END RULE STACK CONTAINS ' + cnt + ' RULES:');
-  stackElement = r.ruleStack;
-  var list = [];
-  while (stackElement) {
-    if (!stackElement._instanceId) {
-      stackElement._instanceId = (++lastElementId);
+    var stackElement = r.ruleStack;
+    var cnt = 0;
+    while (stackElement) {
+      cnt++;
+      stackElement = stackElement.parent; // Changed as per https://github.com/Microsoft/vscode-textmate/issues/91
     }
-    var ruleDesc = grammar._ruleId2desc[stackElement._ruleId]
-    if (!ruleDesc) {
-      list.push('  * no rule description found for rule id: ' + stackElement._ruleId);
-    } else {
-      list.push('  * ' + ruleDesc.debugName + '  -- [' + ruleDesc.id + ',' + stackElement._instanceId + '] "' + stackElement._scopeName + '"');
-    }
-    stackElement = stackElement._parent;
-  }
-  list.reverse();
-  console.log(list.join('\n'));
 
-  ruleStack = r.ruleStack;
-}
+    console.log('@@LINE END RULE STACK CONTAINS ' + cnt + ' RULES:');
+    stackElement = r.ruleStack;
+    var list = [];
+    while (stackElement) {
+      if (!stackElement._instanceId) {
+        stackElement._instanceId = (++lastElementId);
+      }
+      var ruleDesc = grammar._ruleId2desc[stackElement.ruleId] // Changed as per https://github.com/Microsoft/vscode-textmate/issues/91
+      if (!ruleDesc) {
+        list.push('  * no rule description found for rule id: ' + stackElement.ruleId); // Changed as per https://github.com/Microsoft/vscode-textmate/issues/91
+      } else {
+        list.push('  * ' + ruleDesc.debugName + '  -- [' + ruleDesc.id + ',' + stackElement._instanceId + '] "' + stackElement.nameScopesList.scope + '"'); // Changed as per https://github.com/Microsoft/vscode-textmate/issues/91
+      }
+      stackElement = stackElement.parent; // Changed as per https://github.com/Microsoft/vscode-textmate/issues/91
+    }
+    list.reverse();
+    console.log(list.join('\n'));
+
+    ruleStack = r.ruleStack;
+  }
+});


### PR DESCRIPTION
VSCode now uses the vscode-textmate module of 4.x which had breaking API
changes.  This commit updates the module version to 4.x and updates the tests
and inspect script to use the new API surface.

Note that no tests or actual Textmate language files were modified as part of
this process.

Note do not merge until #28 

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
