### PR TITLE
(GH-58) Fix whitespace in heredoc tags

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -607,7 +607,7 @@
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.puppet'
-        'end': '^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1'
+        'end': '^[[:blank:]]*(\\|[[:blank:]]*-|\\||-)?[[:blank:]]*\\1'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.puppet'
@@ -626,7 +626,7 @@
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.string.begin.puppet'
-        'end': '^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1'
+        'end': '^[[:blank:]]*(\\|[[:blank:]]*-|\\||-)?[[:blank:]]*\\1'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.string.end.puppet'

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -606,7 +606,7 @@ repository:
         beginCaptures:
           "0":
             name: "punctuation.definition.string.begin.puppet"
-        end: "^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1"
+        end: "^[[:blank:]]*(\\|[[:blank:]]*-|\\||-)?[[:blank:]]*\\1"
         endCaptures:
           "0":
             name: "punctuation.definition.string.end.puppet"
@@ -625,7 +625,7 @@ repository:
         beginCaptures:
           "0":
             name: "punctuation.definition.string.begin.puppet"
-        end: "^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1"
+        end: "^[[:blank:]]*(\\|[[:blank:]]*-|\\||-)?[[:blank:]]*\\1"
         endCaptures:
           "0":
             name: "punctuation.definition.string.end.puppet"

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -717,7 +717,7 @@
               "name": "punctuation.definition.string.begin.puppet"
             }
           },
-          "end": "^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1",
+          "end": "^[[:blank:]]*(\\|[[:blank:]]*-|\\||-)?[[:blank:]]*\\1",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.string.end.puppet"
@@ -740,7 +740,7 @@
               "name": "punctuation.definition.string.begin.puppet"
             }
           },
-          "end": "^[[:blank:]]*(\\|-|\\||-)?[[:blank:]]*\\1",
+          "end": "^[[:blank:]]*(\\|[[:blank:]]*-|\\||-)?[[:blank:]]*\\1",
           "endCaptures": {
             "0": {
               "name": "punctuation.definition.string.end.puppet"

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -383,7 +383,7 @@ repository:
         beginCaptures:
           '0':
             name: punctuation.definition.string.begin.puppet
-        end: '^[[:blank:]]*(\|-|\||-)?[[:blank:]]*\1'
+        end: '^[[:blank:]]*(\|[[:blank:]]*-|\||-)?[[:blank:]]*\1'
         endCaptures:
           '0':
             name: punctuation.definition.string.end.puppet
@@ -395,7 +395,7 @@ repository:
         beginCaptures:
           '0':
             name: punctuation.definition.string.begin.puppet
-        end: '^[[:blank:]]*(\|-|\||-)?[[:blank:]]*\1'
+        end: '^[[:blank:]]*(\|[[:blank:]]*-|\||-)?[[:blank:]]*\1'
         endCaptures:
           '0':
             name: punctuation.definition.string.end.puppet

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -1138,7 +1138,7 @@
             </dict>
           </dict>
           <key>end</key>
-          <string>^[[:blank:]]*(\|-|\||-)?[[:blank:]]*\1</string>
+          <string>^[[:blank:]]*(\|[[:blank:]]*-|\||-)?[[:blank:]]*\1</string>
           <key>endCaptures</key>
           <dict>
             <key>0</key>
@@ -1174,7 +1174,7 @@
             </dict>
           </dict>
           <key>end</key>
-          <string>^[[:blank:]]*(\|-|\||-)?[[:blank:]]*\1</string>
+          <string>^[[:blank:]]*(\|[[:blank:]]*-|\||-)?[[:blank:]]*\1</string>
           <key>endCaptures</key>
           <dict>
             <key>0</key>


### PR DESCRIPTION
Fixes #58 

Previously the heredoc regex did not allow white space between the pipe and
hyphen character even though the puppet document says that spacing is possible.
This commit updates the regex for the end tag, and adds tests for a few of the
heredoc scenarios.

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
