### PR TITLE
(maint) Release 1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## [1.3.6] - 2020-05-01
+
+### Fixed
+
+- ([GH-58](https://github.com/puppetlabs/puppet-editor-syntax/issues/58)) Fix whitespace in heredoc tags
+
 ## [1.3.5] - 2019-03-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-editor-syntax",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This commit prepares the editor syntax for version 1.3.6 release.