### PR TITLE
(GH-66) undef is not treated as a special value

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -113,6 +113,9 @@
         'name': 'keyword.control.puppet'
   }
   {
+    'include': '#keywords'
+  }
+  {
     'include': '#resource-definition'
   }
   {
@@ -515,6 +518,11 @@
         'include': '#single-quoted-string'
       }
     ]
+  'keywords':
+    'match': '\\b(undef)\\b'
+    'captures':
+      '1':
+        'name': 'keyword.puppet'
   'numbers':
     'patterns': [
       {

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -112,6 +112,9 @@ patterns: [
         name: "keyword.control.puppet"
   }
   {
+    include: "#keywords"
+  }
+  {
     include: "#resource-definition"
   }
   {
@@ -514,6 +517,11 @@ repository:
         include: "#single-quoted-string"
       }
     ]
+  keywords:
+    match: "\\b(undef)\\b"
+    captures:
+      "1":
+        name: "keyword.puppet"
   numbers:
     patterns: [
       {

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -129,6 +129,9 @@
       }
     },
     {
+      "include": "#keywords"
+    },
+    {
       "include": "#resource-definition"
     },
     {
@@ -608,6 +611,14 @@
           "include": "#single-quoted-string"
         }
       ]
+    },
+    "keywords": {
+      "match": "\\b(undef)\\b",
+      "captures": {
+        "1": {
+          "name": "keyword.puppet"
+        }
+      }
     },
     "numbers": {
       "patterns": [

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -68,6 +68,7 @@ patterns:
     captures:
       '1':
         name: keyword.control.puppet
+  - include: '#keywords'
   - include: '#resource-definition'
   - include: '#heredoc'
   - include: '#strings'
@@ -321,6 +322,11 @@ repository:
     patterns:
       - include: '#double-quoted-string'
       - include: '#single-quoted-string'
+  keywords:
+    match: \b(undef)\b
+    captures:
+      '1':
+        name: keyword.puppet
   numbers:
     patterns:
       - comment: HEX 0x 0-f

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-editor-syntax",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -206,6 +206,10 @@
     </dict>
     <dict>
       <key>include</key>
+      <string>#keywords</string>
+    </dict>
+    <dict>
+      <key>include</key>
       <string>#resource-definition</string>
     </dict>
     <dict>
@@ -947,6 +951,21 @@
         </dict>
       </array>
     </dict>
+
+    <key>keywords</key>
+    <dict>
+      <key>match</key>
+      <string>\b(undef)\b</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>keyword.puppet</string>
+        </dict>
+      </dict>
+    </dict>
+
     <!-- Ref https://github.com/puppetlabs/puppet-specifications/blob/master/language/lexical_structure.md#numbers -->
     <key>numbers</key>
     <dict>

--- a/tests/syntaxes/puppet.tmLanguage.js
+++ b/tests/syntaxes/puppet.tmLanguage.js
@@ -708,4 +708,12 @@ describe('puppet.tmLanguage', function() {
       });
     };
   });
+
+  describe('keywords', function() {
+    it("tokenizes undef", function() {
+      var tokens = getLineTokens(grammar, 'if $var != undef { }');
+      expect(tokens[5]).to.eql({value: 'undef', scopes: ['source.puppet', 'keyword.puppet']});
+    });
+
+  });
 });


### PR DESCRIPTION
Fixes #66

Previously undef was not treated as a special value or keyword, which confused
the tokeniser into thinking it was a resource definition.  This commit adds a
keywords matcher to detect undef.

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
