### PR TITLE
(GH-65) Tokenise Node names correctly 

### DIFF
--- a/generated-syntaxes/puppet.tmLanguage.atom.cson
+++ b/generated-syntaxes/puppet.tmLanguage.atom.cson
@@ -18,7 +18,7 @@
     'name': 'comment.block.puppet'
   }
   {
-    'begin': '\\b(node)\\s+(\\"[^\\"]+\\"|\'[^\']+\')\\s*'
+    'begin': '\\b(node)\\b'
     'captures':
       '1':
         'name': 'storage.type.puppet'
@@ -27,6 +27,16 @@
     'end': '(?={)'
     'name': 'meta.definition.class.puppet'
     'patterns': [
+      {
+        'match': '\\bdefault\\b'
+        'name': 'keyword.puppet'
+      }
+      {
+        'include': '#strings'
+      }
+      {
+        'include': '#regex-literal'
+      }
     ]
   }
   {

--- a/generated-syntaxes/puppet.tmLanguage.cson
+++ b/generated-syntaxes/puppet.tmLanguage.cson
@@ -18,7 +18,7 @@ patterns: [
     name: "comment.block.puppet"
   }
   {
-    begin: "\\b(node)\\s+(\\\"[^\\\"]+\\\"|\\'[^\\']+\\')\\s*"
+    begin: "\\b(node)\\b"
     captures:
       "1":
         name: "storage.type.puppet"
@@ -26,7 +26,18 @@ patterns: [
         name: "entity.name.type.class.puppet"
     end: "(?={)"
     name: "meta.definition.class.puppet"
-    patterns: []
+    patterns: [
+      {
+        match: "\\bdefault\\b"
+        name: "keyword.puppet"
+      }
+      {
+        include: "#strings"
+      }
+      {
+        include: "#regex-literal"
+      }
+    ]
   }
   {
     begin: "\\b(class)\\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\\s*"

--- a/generated-syntaxes/puppet.tmLanguage.json
+++ b/generated-syntaxes/puppet.tmLanguage.json
@@ -19,7 +19,7 @@
       "name": "comment.block.puppet"
     },
     {
-      "begin": "\\b(node)\\s+(\\\"[^\\\"]+\\\"|\\'[^\\']+\\')\\s*",
+      "begin": "\\b(node)\\b",
       "captures": {
         "1": {
           "name": "storage.type.puppet"
@@ -30,7 +30,18 @@
       },
       "end": "(?={)",
       "name": "meta.definition.class.puppet",
-      "patterns": []
+      "patterns": [
+        {
+          "match": "\\bdefault\\b",
+          "name": "keyword.puppet"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "include": "#regex-literal"
+        }
+      ]
     },
     {
       "begin": "\\b(class)\\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\\s*",

--- a/generated-syntaxes/puppet.tmLanguage.yaml
+++ b/generated-syntaxes/puppet.tmLanguage.yaml
@@ -10,7 +10,7 @@ patterns:
   - begin: ^\s*/\*
     end: \*/
     name: comment.block.puppet
-  - begin: '\b(node)\s+(\"[^\"]+\"|\''[^\'']+\'')\s*'
+  - begin: \b(node)\b
     captures:
       '1':
         name: storage.type.puppet
@@ -18,7 +18,11 @@ patterns:
         name: entity.name.type.class.puppet
     end: '(?={)'
     name: meta.definition.class.puppet
-    patterns: []
+    patterns:
+      - match: \bdefault\b
+        name: keyword.puppet
+      - include: '#strings'
+      - include: '#regex-literal'
   - begin: '\b(class)\s+((?#Qualified Resource Name)(?:[a-z][a-z0-9_]*)?(?:::[a-z][a-z0-9_]*)+|(?#Bareword Resource Name)[a-z][a-z0-9_]*)\s*'
     captures:
       '1':

--- a/syntaxes/puppet.tmLanguage
+++ b/syntaxes/puppet.tmLanguage
@@ -32,10 +32,11 @@
       <key>name</key>
       <string>comment.block.puppet</string>
     </dict>
+
     <dict>
       <!-- node names are basically open to anything https://puppet.com/docs/puppet/6.4/lang_reserved.html#nodes -->
       <key>begin</key>
-      <string>\b(node)\s+(\"[^\"]+\"|\'[^\']+\')\s*</string>
+      <string>\b(node)\b</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -54,7 +55,22 @@
       <key>name</key>
       <string>meta.definition.class.puppet</string>
       <key>patterns</key>
-      <array />
+      <array>
+        <dict>
+          <key>match</key>
+          <string>\bdefault\b</string>
+          <key>name</key>
+          <string>keyword.puppet</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#strings</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#regex-literal</string>
+        </dict>
+      </array>
     </dict>
     <dict>
       <!-- Class names are specified as per https://puppet.com/docs/puppet/5.0/lang_reserved.html#classes-and-defined-resource-types -->


### PR DESCRIPTION
Fixes #65 

Previously the tokeniser always thought node names must a be a single string,
however they can also be regular expressions and the keyword default. And they
can be a list of these separate by commas.  This commuit updates the node
regular expressions for all of these types of node names and adds tests for
these scenarios

---

Reminder

- [x] Added Tests

- [x] Ran `npm run convert` and committed the changes too
