### PR TITLE
(maint) Release 1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
+## [1.3.7] - 2020-07-10
+
+### Fixed
+
+- ([GH-66](https://github.com/puppetlabs/puppet-editor-syntax/issues/66)) undef is not treated as a special value
+- ([GH-65](https://github.com/puppetlabs/puppet-editor-syntax/issues/65)) Tokenise Node names correctly
+
 ## [1.3.6] - 2020-05-01
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-editor-syntax",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-editor-syntax",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This commit prepares the editor syntax for version 1.3.7 release.
